### PR TITLE
update monospace font stack

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -9,7 +9,7 @@
 }
 
 :root {
-	--font-mono: "Cartograph CF", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace,
+	--font-mono: "Cartograph CF", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 body,

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -8,6 +8,10 @@
 	font-display: swap;
 }
 
+:root {
+	--font-mono: "Cartograph CF", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace,
+}
+
 body,
 html {
 	height: 100%;
@@ -31,7 +35,7 @@ pre {
 
 .line-numbers {
 	color: #908caa;
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	text-align: end;
 	user-select: none;
 	font-size: 15px;
@@ -40,7 +44,7 @@ pre {
 }
 
 #code-view-pre {
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	padding-top: 0;
 	padding-bottom: 0;
 	font-size: 15px;
@@ -49,7 +53,7 @@ pre {
 }
 
 #code-view {
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	padding-top: 0;
 	padding-bottom: 0;
 	line-height: 1.5em;
@@ -57,7 +61,7 @@ pre {
 
 .viewcounter {
 	font-size: 12px;
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	margin-top: 0px;
 	margin-bottom: 0px;
 }
@@ -145,7 +149,7 @@ a:hover :not(.logo) {
 	text-decoration: none;
 	color: #8fbcc8;
 	width: 100%;
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	display: inline-block;
 	background: linear-gradient(
 		to right,
@@ -180,7 +184,7 @@ a:hover :not(.logo) {
 
 #messages li {
 	background-color: rgba(31, 29, 46, 0.8);
-	font-family: Cartograph CF, monospace;
+	font-family: var(--font-mono);
 	color: #e0def4;
 	padding: 7px;
 }


### PR DESCRIPTION
This provides a nice fallback stack to match the user's system monospace font, eg. SF Mono on macOS.